### PR TITLE
fix: Bot restart failed when change settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -580,6 +580,7 @@ AppDataSource.initialize().then(async () => {
         ConfigService.setConfig(settings)
         await botManager.handleBotStatus(
             settings.telegram?.bot?.botToken,
+            settings.telegram?.bot?.chatId,
             settings.telegram?.bot?.enable
         );
         // 修改配置, 重新实例化消息推送

--- a/src/utils/TelegramBotManager.js
+++ b/src/utils/TelegramBotManager.js
@@ -14,18 +14,18 @@ class TelegramBotManager {
     }
 
     async handleBotStatus(botToken, chatId, enable) {
-        const shouldEnableBot = enable && botToken && chatId;
+        const shouldEnableBot = !!(enable && botToken && chatId);
         const botTokenChanged = TelegramBotManager.bot?.token !== botToken;
         const chatIdChanged = TelegramBotManager.bot?.chatId!== chatId;
         if (TelegramBotManager.bot && (!shouldEnableBot || botTokenChanged || chatIdChanged)) {
-            TelegramBotManager.bot.stop();
+            await TelegramBotManager.bot.stop();
             TelegramBotManager.bot = null;
             logTaskEvent(`Telegram机器人已停用`);
         }
 
         if (shouldEnableBot && (!TelegramBotManager.bot || botTokenChanged || chatIdChanged)) {
             TelegramBotManager.bot = new TelegramBotService(botToken, chatId);
-            TelegramBotManager.bot.start()
+            await TelegramBotManager.bot.start()
             .then(() => {
                 logTaskEvent(`Telegram机器人已启动`);
             })

--- a/src/utils/TelegramBotManager.js
+++ b/src/utils/TelegramBotManager.js
@@ -25,7 +25,7 @@ class TelegramBotManager {
 
         if (shouldEnableBot && (!TelegramBotManager.bot || botTokenChanged || chatIdChanged)) {
             TelegramBotManager.bot = new TelegramBotService(botToken, chatId);
-            await TelegramBotManager.bot.start()
+            TelegramBotManager.bot.start()
             .then(() => {
                 logTaskEvent(`Telegram机器人已启动`);
             })


### PR DESCRIPTION
Use await to make sure that bot has stopped before restart.